### PR TITLE
Fix transaction history bug for non-ranged descriptors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -409,12 +409,14 @@ export function DiscoveryFactory(
         });
 
         let gap = 0;
-        index = index || 0; //If it was a passed argument use it; othewise start at zero
+        let indexEvaluated = index || 0; //If it was a passed argument use it; othewise start at zero
         const isRanged = descriptor.indexOf('*') !== -1;
-        while (isRanged ? gap < gapLimit : index < 1 /*once if unranged*/) {
+        while (
+          isRanged ? gap < gapLimit : indexEvaluated < 1 /*once if unranged*/
+        ) {
           const used = await this.#fetchOutput({
             descriptor,
-            ...(isRanged ? { index } : {})
+            ...(isRanged ? { index: indexEvaluated } : {})
           });
 
           if (used) {
@@ -424,7 +426,7 @@ export function DiscoveryFactory(
 
           if (used && next && !nextPromise) nextPromise = next();
 
-          index++;
+          indexEvaluated++;
 
           if (used && onUsed && usedOutputNotified === false) {
             onUsed(descriptorOrDescriptors);

--- a/test/integration/regtest.test.ts
+++ b/test/integration/regtest.test.ts
@@ -12,6 +12,7 @@
 //TODO: test an unrangedDescriptor as above without value. It should not appear???
 //TODO: tests with used both for unrangedDescriptor and ranged and using pubkey instad of bip32, this should be detected
 //TODO: test the rest of methods
+import { vaultsTests } from './vaults';
 import { RegtestUtils } from 'regtest-client';
 import { networks } from 'bitcoinjs-lib';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
@@ -413,3 +414,5 @@ describe('Discovery on regtest', () => {
   //  await.discoverer.discovery!.fetch({
   //});
 });
+
+vaultsTests();

--- a/test/integration/vaults.ts
+++ b/test/integration/vaults.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Jose-Luis Landabaso - https://bitcoinerlab.com
+// Distributed under the MIT software license
+
+import { RegtestUtils } from 'regtest-client';
+import { networks } from 'bitcoinjs-lib';
+import * as secp256k1 from '@bitcoinerlab/secp256k1';
+import * as descriptors from '@bitcoinerlab/descriptors';
+import { mnemonicToSeedSync } from 'bip39';
+const { encode: olderEncode } = require('bip68');
+import { compilePolicy } from '@bitcoinerlab/miniscript';
+import {
+  EsploraExplorer,
+  ESPLORA_LOCAL_REGTEST_URL
+} from '@bitcoinerlab/explorer';
+const { Output, BIP32, ECPair } = descriptors.DescriptorsFactory(secp256k1);
+
+const regtestUtils = new RegtestUtils();
+import { DiscoveryFactory } from '../../dist';
+
+export const vaultsTests = () => {
+  describe('Vaults', () => {
+    const network = networks.regtest;
+    const lockBlocks = 1;
+
+    const SEED =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+    const BALANCE = 10000;
+    let standardDescriptors: Array<string>;
+    let vaultDescriptor: string;
+    let vaultAddress: string;
+    beforeAll(async () => {
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      const POLICY = (older: number) =>
+        `or(pk(@panicKey),99@and(pk(@unvaultKey),older(${older})))`;
+      const older = olderEncode({ blocks: lockBlocks });
+      const { miniscript, issane } = compilePolicy(POLICY(older));
+      if (!issane) throw new Error('Policy not sane');
+
+      const masterNode = BIP32.fromSeed(mnemonicToSeedSync(SEED), network);
+      standardDescriptors = [0, 1].map(change =>
+        descriptors.scriptExpressions.wpkhBIP32({
+          masterNode,
+          network,
+          account: 0,
+          index: '*',
+          change
+        })
+      );
+      const unvaultKey = descriptors.keyExpressionBIP32({
+        masterNode,
+        originPath: "/0'",
+        keyPath: '/0'
+      });
+
+      const panicPair = ECPair.makeRandom();
+      const panicPubKey = panicPair.publicKey;
+
+      vaultDescriptor = `wsh(${miniscript
+        .replace('@unvaultKey', unvaultKey)
+        .replace('@panicKey', panicPubKey.toString('hex'))})`;
+
+      const vaultOutput = new Output({ descriptor: vaultDescriptor, network });
+      vaultAddress = vaultOutput.getAddress();
+      await regtestUtils.faucet(vaultAddress, BALANCE);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+    }, 11000);
+
+    test('discover descriptors', async () => {
+      const { Discovery } = DiscoveryFactory(
+        new EsploraExplorer({ url: ESPLORA_LOCAL_REGTEST_URL }),
+        network
+      );
+      const unspents = await regtestUtils.unspents(vaultAddress);
+      expect(unspents.length).toBe(1);
+      const discovery = new Discovery();
+      const blockHeight = await regtestUtils.height();
+      expect(blockHeight).toBeGreaterThan(0);
+      const explorerBlockHeight = await discovery
+        .getExplorer()
+        .fetchBlockHeight();
+      expect(blockHeight).toBe(explorerBlockHeight);
+      const descriptors = [...standardDescriptors, vaultDescriptor];
+      await discovery.fetch({ descriptors });
+      const { utxos, balance } = discovery.getUtxosAndBalance({ descriptors });
+      expect(utxos.length).toBe(1);
+      expect(balance).toBe(BALANCE);
+    }, 10000);
+  });
+};


### PR DESCRIPTION
Resolved a critical bug where transaction history for non-ranged descriptors was failing if other descriptors had been previously fetched. This update includes adjustments in the DiscoveryFactory function to ensure accurate handling of non-ranged descriptors. Additionally, new tests have been added to cover these scenarios, ensuring robust functionality and preventing similar issues in the future.

Version bumped to 1.0.1 in package.json and package-lock.json to reflect these important changes.