### PR TITLE
Optimize Fetch Calls with Parallelization and Improved Queue Utilization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.0.1",
-        "@bitcoinerlab/explorer": "^0.1.1",
+        "@bitcoinerlab/explorer": "^0.1.2",
         "@bitcoinerlab/secp256k1": "^1.0.5",
         "@types/memoizee": "^0.4.8",
         "bitcoinjs-lib": "^6.1.3",
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@bitcoinerlab/explorer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.1.1.tgz",
-      "integrity": "sha512-ZJK/jAvKGjZCUZvJj02p7m8Uq4Wpvo8xeOdxnZGfUqIZEgJagZeoasBmiqxSUScrN96x6TntW6nmS2oW+5bCIw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.1.2.tgz",
+      "integrity": "sha512-6eC2Lie9KZIImW1lUUk1VzsBT93WQuPOC0lJAdc8uh2lWI619FvUhxzzlsAx6VeTQwyp2Ru7qoRHDv2QhK41Xw==",
       "dependencies": {
         "bitcoinjs-lib": "^6.1.3",
         "electrum-client": "github:BlueWallet/rn-electrum-client#76c0ea35e1a50c47f3a7f818d529ebd100161496",
@@ -6563,9 +6563,9 @@
       }
     },
     "@bitcoinerlab/explorer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.1.1.tgz",
-      "integrity": "sha512-ZJK/jAvKGjZCUZvJj02p7m8Uq4Wpvo8xeOdxnZGfUqIZEgJagZeoasBmiqxSUScrN96x6TntW6nmS2oW+5bCIw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.1.2.tgz",
+      "integrity": "sha512-6eC2Lie9KZIImW1lUUk1VzsBT93WQuPOC0lJAdc8uh2lWI619FvUhxzzlsAx6VeTQwyp2Ru7qoRHDv2QhK41Xw==",
       "requires": {
         "bitcoinjs-lib": "^6.1.3",
         "electrum-client": "github:BlueWallet/rn-electrum-client#76c0ea35e1a50c47f3a7f818d529ebd100161496",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@bitcoinerlab/descriptors": "^2.0.1",
-    "@bitcoinerlab/explorer": "^0.1.1",
+    "@bitcoinerlab/explorer": "^0.1.2",
     "@bitcoinerlab/secp256k1": "^1.0.5",
     "@types/memoizee": "^0.4.8",
     "bitcoinjs-lib": "^6.1.3",


### PR DESCRIPTION
Enhanced fetch call handling by implementing parallelization techniques and leveraging the improved queue implementation from @bitcoinerlab/explorer. These changes significantly boost efficiency in fetching transaction history and related data.

Changes include:
- Parallel fetching of transaction hex data in the #fetchTxs method.
- Concurrent fetching for multiple descriptors in the fetch method.
- Updated package version to 1.0.3.
- Upgraded dependency on @bitcoinerlab/explorer to version 0.1.2.