### PR TITLE
Fix for Descriptor Canonicalization and Type Consistency Issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/deriveData.ts
+++ b/src/deriveData.ts
@@ -31,7 +31,7 @@ export function canonicalize(
   const descriptorArray = Array.isArray(descriptorOrDescriptors)
     ? descriptorOrDescriptors
     : [descriptorOrDescriptors];
-  const canonicalDescriptors: Array<Descriptor> | Descriptor = [];
+  const canonicalDescriptors: Array<Descriptor> = [];
   descriptorArray.forEach(descriptor => {
     const canonicalDescriptor = expand({
       descriptor,
@@ -40,8 +40,15 @@ export function canonicalize(
     if (descriptor !== canonicalDescriptor) isDifferent = true;
     canonicalDescriptors.push(canonicalDescriptor);
   });
-  if (isDifferent) return canonicalDescriptors;
-  else return descriptorOrDescriptors;
+  if (Array.isArray(descriptorOrDescriptors)) {
+    if (isDifferent) return canonicalDescriptors;
+    else return descriptorOrDescriptors;
+  } else {
+    const canonicalDescriptor = canonicalDescriptors[0];
+    if (!canonicalDescriptor)
+      throw new Error(`Could not canonicalize ${descriptorOrDescriptors}`);
+    return canonicalDescriptor;
+  }
 }
 
 export function deriveDataFactory({

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -242,7 +242,7 @@ export function DiscoveryFactory(
       //console.log(`Fetching ${descriptor}, ${internalIndex}`);
       const scriptPubKey = this.#derivers.deriveScriptPubKey(
         networkId,
-        canonicalize(descriptor, network) as string,
+        descriptor,
         internalIndex
       );
       //https://electrumx.readthedocs.io/en/latest/protocol-basics.html#script-hashes
@@ -538,7 +538,9 @@ export function DiscoveryFactory(
         throw new Error(`Pass index (optionally) only for ranged descriptors`);
       const networkId = getNetworkId(network);
       const descriptorData =
-        this.#discoveryData[networkId].descriptorMap[descriptor];
+        this.#discoveryData[networkId].descriptorMap[
+          canonicalize(descriptor, network) as Descriptor
+        ];
       if (!descriptorData) return undefined;
       if (typeof index !== 'number') {
         return {
@@ -558,7 +560,7 @@ export function DiscoveryFactory(
     }
 
     /**
-     * Makes sure that data was retrieved before trying to derive from it
+     * Makes sure that data was retrieved before trying to derive from it.
      */
     #ensureFetched({
       descriptor,
@@ -801,7 +803,7 @@ export function DiscoveryFactory(
           networkId,
           txMap,
           descriptorMap,
-          descriptorOrDescriptors as string,
+          descriptorOrDescriptors as Descriptor,
           internalIndex,
           txStatus
         );
@@ -869,7 +871,7 @@ export function DiscoveryFactory(
         this.#derivers.deriveHistoryByOutput(
           txMap,
           descriptorMap,
-          descriptor,
+          canonicalize(descriptor, network) as Descriptor,
           index,
           txStatus
         ).length
@@ -929,7 +931,7 @@ export function DiscoveryFactory(
         return this.#derivers.deriveHistoryByOutput(
           txMap,
           descriptorMap,
-          descriptorOrDescriptors as string,
+          descriptorOrDescriptors as Descriptor,
           internalIndex,
           txStatus
         );

--- a/test/fixtures/discovery.ts
+++ b/test/fixtures/discovery.ts
@@ -30,6 +30,26 @@ export const fixtures = {
       },
       {
         descriptor:
+          "pkh([a0809f04/44'/1'/10']tpubDDZgrqYqZ8Khmoc8cgxe51g1GchJ9F3MZHebGJEKkX5JtuRHUQysf4sSWiobEeEWNKjg7xVkZSZw549PU8LCwNRXRYhUZGfZ7xxNEE9uoPA/100/*)#52y3898q",
+        range: {
+          1: 100000000,
+          4: 5000000,
+          14: 6000,
+          25: 1500000000
+        }
+      },
+      {
+        descriptor:
+          "pkh([a0809f04/44'/1'/11']tpubDDZgrqYqZ8KhoFt46NvUJd2jkx5WJFjJ1P5HgKkFBWPndykmFg7o8pqJ2jEmzRugsqyDPrkbMXZo7v382Uqav6y34hYCcYhjgtWAYG8BfdR/100/*)#tmgqw53j",
+        range: {}
+      },
+      {
+        descriptor:
+          "pkh([a0809f04/44'/1'/12']tpubDDZgrqYqZ8KhsUuuUYn7Yu48sRy79zAZwps2Tv64RA3HJCmBkCUdeuj3UWz5vMEWBPUGMLF6jpkL9BWoWcbg2xJc5dcfpz8ooLFfboiZfa4/100/0)#4h3cswf0",
+        range: { 'non-ranged': 123123 }
+      },
+      {
+        descriptor:
           "pkh([a0809f04/44'/1'/2']tpubDDZgrqYqZ8KhRWoLmi9dXgxi14b3wuD9afKWgf4t2dGSUaEWmNsZ9Xwa6MxtLA2WakTSVpNL4MGrHBFs9TRr99p9GLN5arF8PWnZNn7P2Gp/100/*)",
         range: {},
         error:


### PR DESCRIPTION
### Problem
Issue #5 highlighted problems with checksumed descriptors: The `canonicalize` function did not return the same type as its input for checksummed descriptors and some functions failed to canonicalize descriptors when deriving data.

### Changes
- **Canonicalize Function Update**: Ensured it returns the correct type (single string or array) matching the input.
- **Improved Data Retrieval**: Canonicalization is now consistently applied before retrieving data,.
- **Test Enhancements**: Updated tests to cover these fixes.
- The version is bumped to 1.0.4, marking significant improvements.

Fixes #5