### PR TITLE
Implement push function to push transactions and update internal state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.1.0",
@@ -1395,9 +1395,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
-      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -7053,9 +7053,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
-      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g=="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -3,7 +3,7 @@
 //import { DiscoveryFactory } from '../dist';
 //import { networks, crypto } from 'bitcoinjs-lib';
 
-test('This lib still needs the following unit tests', () => {
+test('This lib still needs unit tests (most functionalities are testes in the integration tests)', () => {
   expect(true).toBe(true);
 });
 


### PR DESCRIPTION
## Description

This pull request adds a new `push` function to the `Discovery` class, which handles pushing transactions to the network and updating the internal state. The function ensures that the transaction is pushed, verifies its presence in the mempool, and updates the `discoveryData` accordingly.

### Key Changes

- Added `push` function to push transactions and update internal state.
- New `getDescriptorByScriptPubKey` to handle gap limit for descriptor discovery.
- Updated tests to include cases for the `push` function.
- Documentation for new methods and parameters.

### Reason for Changes

The `push` function is essential for ensuring that transactions are correctly pushed to the network and that the internal state of the discovery instance is updated to reflect the latest UTXOs and descriptors. The gap limit handling ensures that new indices within the specified limit in all internally tracked descriptors are properly updated.

### Testing

- Updated integration tests to cover transaction pushing and state updates.

### Documentation

Updated the Typedoc comments for the new `push` function and related methods to provide clear and comprehensive descriptions of their behavior and parameters.

