### PR TITLE
Fix getDescriptorByScriptPubKey to consider all fetched descriptors and add addTransaction function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",


### PR DESCRIPTION
## Description

This pull request addresses a bug in the `getDescriptorByScriptPubKey` function and introduces a new `addTransaction` function. The previous implementation incorrectly searched only in used descriptors, which has been corrected to search in all fetched descriptors. Additionally, the `push` function has been separated into `push` and `addTransaction` for better flexibility.

### Key Changes

- Fixed `getDescriptorByScriptPubKey` to consider all fetched descriptors, not just used ones.
- Added `addTransaction` function to allow adding transactions to the internal state without pushing.
- Updated `push` function to use `addTransaction`.
- Improved documentation for the new methods and parameters.

### Reason for Changes

The fix in `getDescriptorByScriptPubKey` ensures that all fetched descriptors are considered, not just the used ones. This is crucial for accurate transaction handling in `addTransaction` and `push`. The new `addTransaction` function provides flexibility to add transactions when they are pushed by third parties, without requiring a fetch.

### Documentation

Updated the Typedoc comments for the new `addTransaction` function and revised existing comments for clarity.