### PR TITLE
feat: Improve transaction ordering and expose compareTxOrder with enhanced getDescriptor performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,13 @@
 import { DiscoveryFactory, DiscoveryInstance } from './discovery';
 export { DiscoveryFactory, DiscoveryInstance };
 export {
+  TxWithOrder,
   OutputCriteria,
   TxStatus,
   Account,
+  TxoMap,
   Utxo,
   Stxo,
+  IndexedDescriptor,
   TxAttribution
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Transaction } from 'bitcoinjs-lib';
 /**
  * Versions the structure of the data model. This variable should to be
  * changed when any of the types below change.
@@ -84,6 +85,29 @@ export enum TxStatus {
   /** CONFIRMED with at least 1 confirmation */
   CONFIRMED = 'CONFIRMED'
 }
+/**
+ * A string representing an indexed descriptor for ranged descriptors or a
+ * descriptor followed by a separator and the keyword "non-ranged".
+ *
+ * An `IndexedDescriptor` is a descriptor representation what must correspond to
+ * a single output.
+ *
+ * - If it is ranged, then add an integer after the separaror (a
+ * tilde "\~").
+ * - It it is non-ranged, add the string "non-ranged" after the tilde "\~".
+ *
+ * Examples:
+ * pkh([73c5da0a/44'/1'/0']tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba/0/*)\~12
+ * pkh([73c5da0a/44'/1'/0']tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba)\~non-ranged
+ */
+export type IndexedDescriptor = string;
+/**
+ * a Txo is represented in a similar manner as a Utxo, that is,
+ * prevtxId:vout. Hovewer, we use a different type name to denote we're dealing
+ * here with tx outputs that may have been spent or not
+ */
+type Txo = string;
+export type TxoMap = Record<Txo, IndexedDescriptor>;
 
 /**
  * Type definition for Transaction ID.
@@ -102,6 +126,12 @@ export type Utxo = string; //`${txId}:${vout}`
  * ${recipientTxId}:${recipientVin}
  */
 export type Stxo = string; //`${txId}:${vout}:${recipientTxId}:${recipientVin}`
+
+export type TxWithOrder = {
+  blockHeight: number;
+  tx?: Transaction;
+  txHex?: string;
+};
 
 /**
  * Type definition for Transaction Information.

--- a/test/integration/regtest.test.ts
+++ b/test/integration/regtest.test.ts
@@ -32,7 +32,8 @@ import {
   Account,
   TxStatus,
   Utxo,
-  Stxo
+  Stxo,
+  TxoMap
 } from '../../dist';
 type DescriptorIndex = number | 'non-ranged';
 const ESPLORA_CATCHUP_TIME = 5000;
@@ -330,11 +331,13 @@ describe('Discovery on regtest', () => {
           let balanceDefault: number;
           let utxosDefault: Array<Utxo>;
           let stxosDefault: Array<Stxo>;
+          let txoMapDefault: TxoMap;
           test(`getUtxosAndBalance default status for ${descriptor} using ${discoverer.name} after ${totalMined} blocks`, () => {
             ({
               balance: balanceDefault,
               utxos: utxosDefault,
-              stxos: stxosDefault
+              stxos: stxosDefault,
+              txoMap: txoMapDefault
             } = discoverer.discovery!.getUtxosAndBalance({
               descriptor
             }));
@@ -348,15 +351,19 @@ describe('Discovery on regtest', () => {
             ).toEqual({
               balance: balanceDefault,
               utxos: utxosDefault,
-              stxos: stxosDefault
+              stxos: stxosDefault,
+              txoMap: txoMapDefault
             });
           });
           test(`getUtxosAndBalance ALL for ${descriptor} using ${discoverer.name} after ${totalMined} blocks`, () => {
-            const { balance: balanceAll, utxos: utxosAll } =
-              discoverer.discovery!.getUtxosAndBalance({
-                descriptor,
-                txStatus: TxStatus.ALL
-              });
+            const {
+              balance: balanceAll,
+              utxos: utxosAll,
+              txoMap: txoMapAll
+            } = discoverer.discovery!.getUtxosAndBalance({
+              descriptor,
+              txStatus: TxStatus.ALL
+            });
             expect(balanceAll).toEqual(totalBalance);
             expect(balanceAll).toEqual(balanceDefault);
             expect(utxosAll.length).toEqual(totalUtxosCount);
@@ -365,14 +372,22 @@ describe('Discovery on regtest', () => {
               new Discovery({
                 imported: discoverer.discovery!.export()
               }).getUtxosAndBalance({ descriptor, txStatus: TxStatus.ALL })
-            ).toEqual({ balance: balanceAll, utxos: utxosAll, stxos: [] });
+            ).toEqual({
+              balance: balanceAll,
+              utxos: utxosAll,
+              stxos: [],
+              txoMap: txoMapAll
+            });
           });
           test(`getUtxosAndBalance CONFIRMED for ${descriptor} using ${discoverer.name} after ${totalMined} blocks`, () => {
-            const { balance: balanceConfirmed, utxos: utxosConfirmed } =
-              discoverer.discovery!.getUtxosAndBalance({
-                descriptor,
-                txStatus: TxStatus.CONFIRMED
-              });
+            const {
+              balance: balanceConfirmed,
+              utxos: utxosConfirmed,
+              txoMap: txoMapConfirmed
+            } = discoverer.discovery!.getUtxosAndBalance({
+              descriptor,
+              txStatus: TxStatus.CONFIRMED
+            });
             expect(balanceConfirmed).toEqual(totalMined > 0 ? totalBalance : 0);
             expect(utxosConfirmed.length).toEqual(
               totalMined > 0 ? totalUtxosCount : 0
@@ -388,15 +403,19 @@ describe('Discovery on regtest', () => {
             ).toEqual({
               balance: balanceConfirmed,
               utxos: utxosConfirmed,
-              stxos: []
+              stxos: [],
+              txoMap: txoMapConfirmed
             });
           });
           test(`getUtxosAndBalance IRREVERSIBLE for ${descriptor} using ${discoverer.name} after ${totalMined} blocks`, () => {
-            const { balance: balanceIrreversible, utxos: utxosIrreversible } =
-              discoverer.discovery!.getUtxosAndBalance({
-                descriptor,
-                txStatus: TxStatus.IRREVERSIBLE
-              });
+            const {
+              balance: balanceIrreversible,
+              utxos: utxosIrreversible,
+              txoMap: txoMapIrreversible
+            } = discoverer.discovery!.getUtxosAndBalance({
+              descriptor,
+              txStatus: TxStatus.IRREVERSIBLE
+            });
             expect(balanceIrreversible).toEqual(
               totalMined >= irrevConfThresh ? totalBalance : 0
             );
@@ -414,7 +433,8 @@ describe('Discovery on regtest', () => {
             ).toEqual({
               balance: balanceIrreversible,
               utxos: utxosIrreversible,
-              stxos: []
+              stxos: [],
+              txoMap: txoMapIrreversible
             });
           });
         }


### PR DESCRIPTION
## Description

This PR improves the transaction ordering mechanism to ensure that transactions within the same block are correctly ordered, especially when they depend on each other. It also exposes the `compareTxOrder` function, allowing external sorting of transactions. Additionally, it introduces `TxoMap` to map all transaction outputs with their corresponding indexed descriptors, significantly improving the performance of `getDescriptor`. Key updates include:

- Enhanced transaction ordering to correctly sort dependent transactions within the same block
- Exposed `compareTxOrder` function for external use
- Addition of `TxoMap` to map transaction outputs to their corresponding descriptor (and index)
- Improved `getDescriptor` performance by utilizing `TxoMap`
- Updates to `deriveDataFactory` and `DiscoveryFactory` for new functionalities
- Enhancements to tests to ensure coverage of the new features