### PR TITLE
fix: correct txo validation in getDescriptor and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1190,7 +1190,7 @@ export function DiscoveryFactory(
       const split = txo.split(':');
       if (utxo && split.length !== 2)
         throw new Error(`Error: invalid utxo: ${utxo}`);
-      if (!utxo && split.length !== 3)
+      if (!utxo && split.length !== 2 && split.length !== 3)
         throw new Error(`Error: invalid txo: ${txo}`);
       const txId = split[0];
       if (!txId) throw new Error(`Error: invalid txo: ${txo}`);


### PR DESCRIPTION
- Fixed txo validation to correctly handle cases with two or three parts
- Bumped version to 1.2.4