### PR TITLE
chore: update to @bitcoinerlab/explorer v0.4.0 and adapt API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To get started, follow the steps below:
    await explorer.connect();
    const discovery = new Discovery();
    // Perform discovery operations...
-   await explorer.close();
+   explorer.close();
    ```
 
    The [`Discovery` constructor](https://bitcoinerlab.com/modules/discovery/api/classes/_Internal_.Discovery.html#constructor), `new Discovery({ descriptorsCacheSize, outputsPerDescriptorCacheSize })`, accepts an optional object with two properties that are crucial for managing the application's memory usage:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.2.6",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.2.0",
-        "@bitcoinerlab/explorer": "^0.3.2",
+        "@bitcoinerlab/explorer": "^0.4.0",
         "@bitcoinerlab/secp256k1": "^1.1.1",
         "@types/memoizee": "^0.4.8",
         "bitcoinjs-lib": "^6.1.5",
@@ -766,13 +766,21 @@
         }
       }
     },
+    "node_modules/@bitcoinerlab/electrum-client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/electrum-client/-/electrum-client-1.0.4.tgz",
+      "integrity": "sha512-0XwDngE1YgS4wRBTI2JuKB+qGukK20CltI8jRuJ3t5C1zol8TSRvgNuqjBs74jVVeGlDJnTBo5g6myb7GduZ2g==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@bitcoinerlab/explorer": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.3.2.tgz",
-      "integrity": "sha512-tqApM8ywwFHuoah/VrmA+wdWwOpXy1h+zC3rt+jowc5nHz5RjjaqPllP10nimNYCMSCoG8hBTT15pg8iKgL4aQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.4.0.tgz",
+      "integrity": "sha512-kBePb1jdtrryoVPYe6eZNFxkQw/6IcWuIncvdfjcG3+CBeoZLjXPEyFprBj82B3jeNF/8Gn2QsA/JzsqlrjMpg==",
       "dependencies": {
-        "bitcoinjs-lib": "^6.1.3",
-        "electrum-client": "github:BlueWallet/rn-electrum-client#1bfe3cc4249d5440b816baac942b0cfa921eebf9"
+        "@bitcoinerlab/electrum-client": "^1.0.4",
+        "bitcoinjs-lib": "^6.1.3"
       }
     },
     "node_modules/@bitcoinerlab/miniscript": {
@@ -2703,15 +2711,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.590.tgz",
       "integrity": "sha512-hohItzsQcG7/FBsviCYMtQwUSWvVF7NVqPOnJCErWsAshsP/CR2LAXdmq276RbESNdhxiAq5/vRo1g2pxGXVww==",
       "dev": true
-    },
-    "node_modules/electrum-client": {
-      "version": "3.1.0",
-      "resolved": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#1bfe3cc4249d5440b816baac942b0cfa921eebf9",
-      "integrity": "sha512-91uT4Ty4YNYvmxgmF3p+GCdygbXrsReFwVpIbkk+GQ2uUNRwUeQwVr8dK/GvnQbRbdk4euQuKubaju3mdQR+SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6559,13 +6558,18 @@
         "varuint-bitcoin": "^1.1.2"
       }
     },
+    "@bitcoinerlab/electrum-client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/electrum-client/-/electrum-client-1.0.4.tgz",
+      "integrity": "sha512-0XwDngE1YgS4wRBTI2JuKB+qGukK20CltI8jRuJ3t5C1zol8TSRvgNuqjBs74jVVeGlDJnTBo5g6myb7GduZ2g=="
+    },
     "@bitcoinerlab/explorer": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.3.2.tgz",
-      "integrity": "sha512-tqApM8ywwFHuoah/VrmA+wdWwOpXy1h+zC3rt+jowc5nHz5RjjaqPllP10nimNYCMSCoG8hBTT15pg8iKgL4aQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.4.0.tgz",
+      "integrity": "sha512-kBePb1jdtrryoVPYe6eZNFxkQw/6IcWuIncvdfjcG3+CBeoZLjXPEyFprBj82B3jeNF/8Gn2QsA/JzsqlrjMpg==",
       "requires": {
-        "bitcoinjs-lib": "^6.1.3",
-        "electrum-client": "github:BlueWallet/rn-electrum-client#1bfe3cc4249d5440b816baac942b0cfa921eebf9"
+        "@bitcoinerlab/electrum-client": "^1.0.4",
+        "bitcoinjs-lib": "^6.1.3"
       }
     },
     "@bitcoinerlab/miniscript": {
@@ -7998,11 +8002,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.590.tgz",
       "integrity": "sha512-hohItzsQcG7/FBsviCYMtQwUSWvVF7NVqPOnJCErWsAshsP/CR2LAXdmq276RbESNdhxiAq5/vRo1g2pxGXVww==",
       "dev": true
-    },
-    "electrum-client": {
-      "version": "git+ssh://git@github.com/BlueWallet/rn-electrum-client.git#1bfe3cc4249d5440b816baac942b0cfa921eebf9",
-      "integrity": "sha512-91uT4Ty4YNYvmxgmF3p+GCdygbXrsReFwVpIbkk+GQ2uUNRwUeQwVr8dK/GvnQbRbdk4euQuKubaju3mdQR+SQ==",
-      "from": "electrum-client@github:BlueWallet/rn-electrum-client#1bfe3cc4249d5440b816baac942b0cfa921eebf9"
     },
     "emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@bitcoinerlab/descriptors": "^2.2.0",
-    "@bitcoinerlab/explorer": "^0.3.2",
+    "@bitcoinerlab/explorer": "^0.4.0",
     "@bitcoinerlab/secp256k1": "^1.1.1",
     "@types/memoizee": "^0.4.8",
     "bitcoinjs-lib": "^6.1.5",

--- a/test/integration/discovery.test.ts
+++ b/test/integration/discovery.test.ts
@@ -142,7 +142,7 @@ for (const network of [networks.bitcoin]) {
             //);
           }
           //console.log(JSON.stringify(discovery.getDiscoveryInfo(), null, 2));
-          await explorerAndInfo.explorer.close();
+          explorerAndInfo.explorer.close();
         },
         180 * 10 * 1000 //30 minutes
       );

--- a/test/integration/regtest.test.ts
+++ b/test/integration/regtest.test.ts
@@ -578,9 +578,9 @@ describe('Discovery on regtest', () => {
   }
 
   for (const { explorer, name } of discoverers) {
-    test(`Closes ${name}`, async () => {
-      expect(async () => {
-        await explorer.close();
+    test(`Closes ${name}`, () => {
+      expect(() => {
+        explorer.close();
       }).not.toThrow();
     });
   }


### PR DESCRIPTION
- Updated `@bitcoinerlab/explorer` dependency to version `^0.4.0`.
- Refactored code to align with the updated Explorer API:
  - Replaced `await explorer.close()` with `explorer.close()` as `close` is now synchronous.
  - Removed `requestNetworkConfirmation` parameter usage in `isConnected` calls.
- Updated integration tests to reflect changes in the Explorer API.
- Bumped package version to `1.3.0` to reflect the dependency update and associated changes.