### PR TITLE
Update `@bitcoinerlab/descriptors` to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.2.0",
+        "@bitcoinerlab/descriptors": "^2.2.1",
         "@bitcoinerlab/explorer": "^0.4.0",
-        "@bitcoinerlab/secp256k1": "^1.1.1",
+        "@bitcoinerlab/secp256k1": "^1.2.0",
         "@types/memoizee": "^0.4.8",
         "bitcoinjs-lib": "^6.1.5",
         "immer": "^9.0.21",
@@ -745,12 +745,12 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.0.tgz",
-      "integrity": "sha512-z9GOZYT5jO8oE4aq8XF0czGW1W9JrJXdslUaCfUMEMo5KnygKZhOFXZCHEvtdrEXBACURh1+b/MVhy3pH9Pi7g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
+      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.4.0",
-        "@bitcoinerlab/secp256k1": "^1.1.1",
+        "@bitcoinerlab/secp256k1": "^1.2.0",
         "bip32": "^4.0.0",
         "bitcoinjs-lib": "^6.1.3",
         "ecpair": "^2.1.0",
@@ -792,12 +792,11 @@
       }
     },
     "node_modules/@bitcoinerlab/secp256k1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.1.1.tgz",
-      "integrity": "sha512-uhjW51WfVLpnHN7+G0saDcM/k9IqcyTbZ+bDgLF3AX8V/a3KXSE9vn7UPBrcdU72tp0J4YPR7BHp2m7MLAZ/1Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.2.0.tgz",
+      "integrity": "sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==",
       "dependencies": {
-        "@noble/hashes": "^1.1.5",
-        "@noble/secp256k1": "^1.7.1"
+        "@noble/curves": "^1.7.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1323,27 +1322,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+    "node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+    "node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6545,12 +6547,12 @@
       }
     },
     "@bitcoinerlab/descriptors": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.0.tgz",
-      "integrity": "sha512-z9GOZYT5jO8oE4aq8XF0czGW1W9JrJXdslUaCfUMEMo5KnygKZhOFXZCHEvtdrEXBACURh1+b/MVhy3pH9Pi7g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
+      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
       "requires": {
         "@bitcoinerlab/miniscript": "^1.4.0",
-        "@bitcoinerlab/secp256k1": "^1.1.1",
+        "@bitcoinerlab/secp256k1": "^1.2.0",
         "bip32": "^4.0.0",
         "bitcoinjs-lib": "^6.1.3",
         "ecpair": "^2.1.0",
@@ -6581,12 +6583,11 @@
       }
     },
     "@bitcoinerlab/secp256k1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.1.1.tgz",
-      "integrity": "sha512-uhjW51WfVLpnHN7+G0saDcM/k9IqcyTbZ+bDgLF3AX8V/a3KXSE9vn7UPBrcdU72tp0J4YPR7BHp2m7MLAZ/1Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.2.0.tgz",
+      "integrity": "sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==",
       "requires": {
-        "@noble/hashes": "^1.1.5",
-        "@noble/secp256k1": "^1.7.1"
+        "@noble/curves": "^1.7.0"
       }
     },
     "@eslint-community/eslint-utils": {
@@ -6992,15 +6993,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+    "@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "requires": {
+        "@noble/hashes": "1.6.0"
+      }
     },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    "@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -43,9 +43,9 @@
     "dist"
   ],
   "dependencies": {
-    "@bitcoinerlab/descriptors": "^2.2.0",
+    "@bitcoinerlab/descriptors": "^2.2.1",
     "@bitcoinerlab/explorer": "^0.4.0",
-    "@bitcoinerlab/secp256k1": "^1.1.1",
+    "@bitcoinerlab/secp256k1": "^1.2.0",
     "@types/memoizee": "^0.4.8",
     "bitcoinjs-lib": "^6.1.5",
     "immer": "^9.0.21",

--- a/test/integration/discovery.test.ts
+++ b/test/integration/discovery.test.ts
@@ -44,19 +44,29 @@ for (const network of [networks.bitcoin]) {
         //host: 'btc.lastingcoin.net', //time out on bitcoind
         //host: 'electrum.bitcoinserver.nl', //ETIMEDOUT - this is a small server, low resources.
         //host: 'fulcrum.not.fyi', //TIMEOUT
-        //host: 'bolt.schulzemic.net', // -> Mega fast
-        //host: 'fulcrum.theuplink.net', //TIMEOUT
-        //host: 'f006.fuchsia.fastwebserver.de', fulcrum fast on recache
-        //host: 'electrum-btc.leblancnet.us', //Electrumx
-        host: 'electrum1.bluewallet.io', //Also quite fast TBH COLD: FirstCall: 29375 ms - SecondCall: 3714 ms - HOT: SIMILAR
-        //port: 50002,
-        port: 443,
+        //
+        host: 'bolt.schulzemic.net', // -> Mega fast
+        port: 50002,
         protocol: 'ssl',
+        //
+        //host: 'fulcrum.theuplink.net', //TIMEOUT
+        //host: 'f006.fuchsia.fastwebserver.de', //fulcrum fast on recache
+        //host: 'electrum-btc.leblancnet.us', //Electrumx
+        //
+        //host: 'electrum1.bluewallet.io', //Also quite fast TBH COLD: FirstCall: 29375 ms - SecondCall: 3714 ms - HOT: SIMILAR
+        //port: 443,
+        //protocol: 'ssl',
+        //
+        //
+        //host: 'blockstream.info', //ssl, port 700
+        //port: 700,
+        //protocol: 'ssl',
+        //
         network,
         irrevConfThresh: 3,
         maxTxPerScriptPubKey: 1000
       }),
-      info: 'electrum1.bluewallet.io'
+      info: 'f006.fuchsia.fastwebserver.de'
     }
 
     //Some servers: https://1209k.com/bitcoin-eye/ele.php


### PR DESCRIPTION
- chore: upgrade @bitcoinerlab/secp256k1 to version 1.2.0 and dependent https://github.com/bitcoinerlab packages
- test: update integration electrum servers