### PR TITLE
feat: update the dependency to @bitcoinerlab/descriptors v2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/
 webdocs/
 TODO
 session.vim
+.aider*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.2.1",
+        "@bitcoinerlab/descriptors": "^2.3.0",
         "@bitcoinerlab/explorer": "^0.4.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@types/memoizee": "^0.4.8",
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
-      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.0.tgz",
+      "integrity": "sha512-xRLF8dE7RdfrhPjRigj3mhOZcojGhTx8DB87oWYE8yzPHRR6Ow5HDECBynLFp/5Idf7m2vifNK7SI/cCu8nuaQ==",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.4.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -6547,9 +6547,9 @@
       }
     },
     "@bitcoinerlab/descriptors": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
-      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.0.tgz",
+      "integrity": "sha512-xRLF8dE7RdfrhPjRigj3mhOZcojGhTx8DB87oWYE8yzPHRR6Ow5HDECBynLFp/5Idf7m2vifNK7SI/cCu8nuaQ==",
       "requires": {
         "@bitcoinerlab/miniscript": "^1.4.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -7047,9 +7047,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -43,7 +43,7 @@
     "dist"
   ],
   "dependencies": {
-    "@bitcoinerlab/descriptors": "^2.2.1",
+    "@bitcoinerlab/descriptors": "^2.3.0",
     "@bitcoinerlab/explorer": "^0.4.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@types/memoizee": "^0.4.8",


### PR DESCRIPTION
feat: update the dependency to @bitcoinerlab/descriptors v2.3.0, which adds support for single-key taproot descriptors