### PR TITLE
Migrate discovery to bitcoinjs-lib v7 and bigint monetary API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The @bitcoinerlab/discovery library, written in TypeScript, provides a method fo
 
 - **Data Derivation:** The library maintains a compact internal structure of information and provides methods to query and derive useful data from it. For example, Balances and UTXOs are computed on-the-fly from raw data, while advanced memoization techniques ensure efficiency. This compact data model allows the library to focus on retrieving and storing only transaction data, eliminating the need to download and keep balances or UTXOs in sync.
 
+## Version Compatibility
+
+- `@bitcoinerlab/discovery@2.x` is aligned with `bitcoinjs-lib@7`, `@bitcoinerlab/descriptors@3`, and `@bitcoinerlab/explorer@1`.
+- This version is a breaking change: monetary amounts are now exposed as `bigint` (for example, `balance`, attribution values, and `netReceived`).
+
 ## Usage
 
 To get started, follow the steps below:
@@ -125,12 +130,13 @@ To get started, follow the steps below:
      const { utxos } = discovery.getUtxos({ descriptor });
      ```
 
-   - **Calculating Balance**:
-     Use [`getBalance`](https://bitcoinerlab.com/modules/discovery/api/classes/_Internal_.Discovery.html#getBalance) to calculate the total balance from the fetched data:
+    - **Calculating Balance**:
+      Use [`getBalance`](https://bitcoinerlab.com/modules/discovery/api/classes/_Internal_.Discovery.html#getBalance) to calculate the total balance from the fetched data:
 
-     ```typescript
-     const { balance } = discovery.getBalance({ descriptor });
-     ```
+      ```typescript
+      const balance = discovery.getBalance({ descriptor });
+      // balance is bigint (satoshis)
+      ```
 
    Other methods to derive or calculate data include:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,28 @@
 {
   "name": "@bitcoinerlab/discovery",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/discovery",
-      "version": "1.5.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.3.4",
-        "@bitcoinerlab/explorer": "^0.4.2",
+        "@bitcoinerlab/descriptors": "^3.0.2",
+        "@bitcoinerlab/explorer": "^1.0.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
         "@types/memoizee": "^0.4.8",
-        "bitcoinjs-lib": "^6.1.7",
+        "bitcoinjs-lib": "^7.0.1",
         "immer": "^9.0.21",
         "lodash.clonedeep": "^4.5.0",
         "memoizee": "^0.4.15",
-        "shallow-equal": "^3.1.0"
+        "shallow-equal": "^3.1.0",
+        "uint8array-tools": "^0.0.9"
       },
       "devDependencies": {
         "@bitcoinerlab/configs": "^2.0.0",
+        "@bitcoinerlab/miniscript-policies": "^1.1.0",
         "@types/lodash.clonedeep": "^4.5.9",
         "bip39": "^3.1.0",
         "regtest-client": "^0.2.1"
@@ -566,24 +568,24 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.4.tgz",
-      "integrity": "sha512-6AxmdduM28PnqeBweZ/3QXzx6iIw+Rz3ET89M6pAtNsW1NtLirEHRADXXY2ALKDni3Co6gwxxRqlqPMoQ3lFBQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-3.0.2.tgz",
+      "integrity": "sha512-qU8BqHF4t8/PV3jRWfxH+wobkK0cirsDCMmhyFPU0ttwVEDEsWB9IsbmYR7K3nZihFWbPx2E4zz0iHLD1Kf8aQ==",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/miniscript": "^1.4.3",
+        "@bitcoinerlab/miniscript": "^2.0.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
-        "bip32": "^4.0.0",
-        "bitcoinjs-lib": "^6.1.7",
-        "ecpair": "^2.1.0",
+        "bip32": "github:bitcoinjs/bip32#9e4471ddad38c2d344c1167048072f1c569a115e",
+        "bitcoinjs-lib": "^7.0.1",
+        "ecpair": "^3.0.1",
         "lodash.memoize": "^4.1.2",
-        "varuint-bitcoin": "^1.1.2"
+        "varuint-bitcoin": "^2.0.0"
       },
       "peerDependencies": {
-        "ledger-bitcoin": "^0.2.2"
+        "@ledgerhq/ledger-bitcoin": "^0.3.0"
       },
       "peerDependenciesMeta": {
-        "ledger-bitcoin": {
+        "@ledgerhq/ledger-bitcoin": {
           "optional": true
         }
       }
@@ -598,21 +600,32 @@
       }
     },
     "node_modules/@bitcoinerlab/explorer": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-0.4.2.tgz",
-      "integrity": "sha512-lriwfjxxV7UC12ehW1I82bMvz4wbAEaYZWSZNBaYHXojutAiGTWpDolDd2AdYfkfEVZUariqXEbiv3KZ4BmUsg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/explorer/-/explorer-1.0.0.tgz",
+      "integrity": "sha512-pfZeu5fpWkJDvaVCqfpaxd/OJflvlV3cuJ0gkiH+TTc1a644iEfdqicADhww/83Kd1oHlu/CB+SsgNeIioCA8Q==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/electrum-client": "^1.0.4",
-        "bitcoinjs-lib": "^6.1.7"
+        "bitcoinjs-lib": "^7.0.1"
       }
     },
     "node_modules/@bitcoinerlab/miniscript": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-1.4.3.tgz",
-      "integrity": "sha512-gf7WK4dKJJJl+IgLGmkTOxXQLiCje9c9y4wTLC+cyt0tBDTiSXgsG0X8FFaXf4d+34b8B5p/EJGvRd7mEYB6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript/-/miniscript-2.0.0.tgz",
+      "integrity": "sha512-P8yyubPf6lphmIZfyD/ZbhT/umJX7zH1mKjGql7z0Qt+xuffnz2AueQqq2/01VE2rTIq80VM0oRFdJClGBYx/g==",
       "license": "MIT",
       "dependencies": {
+        "bip68": "^1.0.4"
+      }
+    },
+    "node_modules/@bitcoinerlab/miniscript-policies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/miniscript-policies/-/miniscript-policies-1.1.0.tgz",
+      "integrity": "sha512-ufbWulrnZeEFwmh7O6Yy+d8W1RP64H4u1LNEEnpYn8JQCUs4tZm39sb3BSE0h4eO5QuszU0Va8QSLa98/1/4bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/miniscript": "^2.0.0",
         "bip68": "^1.0.4"
       }
     },
@@ -2579,6 +2592,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -2697,9 +2711,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2719,27 +2733,41 @@
       "license": "MIT"
     },
     "node_modules/bip174": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
-      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
+      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
       "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/bip32": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-4.0.0.tgz",
-      "integrity": "sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==",
+      "version": "5.0.1",
+      "resolved": "git+ssh://git@github.com/bitcoinjs/bip32.git#9e4471ddad38c2d344c1167048072f1c569a115e",
+      "integrity": "sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "@scure/base": "^1.1.1",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/bip39": {
@@ -2762,20 +2790,21 @@
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
-      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.1.tgz",
+      "integrity": "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.1.1",
-        "bs58check": "^3.0.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.1.2"
+        "bip174": "^3.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^1.2.0",
+        "varuint-bitcoin": "^2.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2836,22 +2865,22 @@
       }
     },
     "node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "license": "MIT",
       "dependencies": {
-        "base-x": "^4.0.0"
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/bs58check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
-      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/bser": {
@@ -2875,6 +2904,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2893,6 +2923,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2906,6 +2937,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3006,6 +3038,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
       "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -3157,12 +3190,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
@@ -3308,6 +3343,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3377,6 +3413,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3395,17 +3432,26 @@
       "license": "MIT"
     },
     "node_modules/ecpair": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-2.1.0.tgz",
-      "integrity": "sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-3.0.1.tgz",
+      "integrity": "sha512-uz8wMFvtdr58TLrXnAesBsoMEyY8UudLOfApcyg40XfZjP+gt1xO4cuZSIkZ8hTMTQ8+ETgt7xSIV4eM7M6VNw==",
       "license": "MIT",
       "dependencies": {
-        "randombytes": "^2.1.0",
-        "typeforce": "^1.18.0",
-        "wif": "^2.0.6"
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ecpair/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3531,6 +3577,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3540,6 +3587,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3577,6 +3625,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4334,6 +4383,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -4388,6 +4438,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4458,6 +4509,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4492,6 +4544,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4600,6 +4653,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4649,6 +4703,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -4677,6 +4732,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4689,6 +4745,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4704,6 +4761,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
       "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -4719,6 +4777,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4844,6 +4903,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4943,6 +5003,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5240,6 +5301,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -5301,6 +5363,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6271,6 +6334,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6280,6 +6344,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
@@ -6868,6 +6933,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6944,6 +7010,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -7027,6 +7094,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -7043,6 +7111,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7058,12 +7127,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
@@ -7230,6 +7301,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
       "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hash-base": "^3.1.2",
@@ -7287,6 +7359,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7355,6 +7428,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -7403,6 +7477,7 @@
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -7626,6 +7701,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7635,6 +7711,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-length": {
@@ -8036,6 +8113,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "^2.0.5",
@@ -8126,6 +8204,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8233,17 +8312,11 @@
         "typedoc": "^0.28.1"
       }
     },
-    "node_modules/typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8259,6 +8332,15 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -8366,6 +8448,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -8383,13 +8466,36 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/varuint-bitcoin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.1.1"
+        "uint8array-tools": "^0.0.8"
+      }
+    },
+    "node_modules/varuint-bitcoin/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/walker": {
@@ -8489,6 +8595,7 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -8507,41 +8614,12 @@
       }
     },
     "node_modules/wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
       "license": "MIT",
       "dependencies": {
-        "bs58check": "<3.0.0"
-      }
-    },
-    "node_modules/wif/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/wif/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/wif/node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "license": "MIT",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bitcoinerlab/discovery",
   "description": "A TypeScript library for retrieving Bitcoin funds from ranged descriptors, leveraging @bitcoinerlab/explorer for standardized access to multiple blockchain explorers.",
   "homepage": "https://github.com/bitcoinerlab/discovery",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "prettier": "@bitcoinerlab/configs/prettierConfig.json",
@@ -45,18 +45,20 @@
     "dist"
   ],
   "dependencies": {
-    "@bitcoinerlab/descriptors": "^2.3.4",
-    "@bitcoinerlab/explorer": "^0.4.2",
+    "@bitcoinerlab/descriptors": "^3.0.2",
+    "@bitcoinerlab/explorer": "^1.0.0",
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@types/memoizee": "^0.4.8",
-    "bitcoinjs-lib": "^6.1.7",
+    "bitcoinjs-lib": "^7.0.1",
     "immer": "^9.0.21",
     "lodash.clonedeep": "^4.5.0",
     "memoizee": "^0.4.15",
-    "shallow-equal": "^3.1.0"
+    "shallow-equal": "^3.1.0",
+    "uint8array-tools": "^0.0.9"
   },
   "devDependencies": {
     "@bitcoinerlab/configs": "^2.0.0",
+    "@bitcoinerlab/miniscript-policies": "^1.1.0",
     "@types/lodash.clonedeep": "^4.5.9",
     "bip39": "^3.1.0",
     "regtest-client": "^0.2.1"

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,13 +202,13 @@ export type TxAttribution = {
   ins: Array<{
     //none are set if the prev output cannot be described by one of the owned descriptors
     ownedPrevTxo: Utxo | false; //the prev output where funds come from in this input
-    value?: number; //amount received
+    value?: bigint; //amount received
   }>;
   outs: Array<{
     ownedTxo: Utxo | false; //the owned output where funds are sent in this tx output. Not set if the output is not owned by the descriptors
-    value: number; //amount sent. Always set
+    value: bigint; //amount sent. Always set
   }>;
-  netReceived: number;
+  netReceived: bigint;
   type: 'CONSOLIDATED' | 'RECEIVED' | 'SENT' | 'RECEIVED_AND_SENT';
 };
 

--- a/test/fixtures/discovery.ts
+++ b/test/fixtures/discovery.ts
@@ -12,10 +12,10 @@ export const fixtures = {
         descriptor:
           "pkh([a0809f04/44'/1'/0']tpubDDZgrqYqZ8KhKDKYp1Skpg4S11C3PptLU5LgTg57HY6B3qEYb571N2AQUbRoAZduqtKnBDJDerXS588TKTcB3AP7rpoeUHu49mqZz4Ctnjp/100/*)",
         range: {
-          1: 100000000,
-          4: 5000000,
-          14: 6000,
-          25: 1500000000
+          1: 100000000n,
+          4: 5000000n,
+          14: 6000n,
+          25: 1500000000n
         }
       },
       {
@@ -26,16 +26,16 @@ export const fixtures = {
       {
         descriptor:
           "pkh([a0809f04/44'/1'/2']tpubDDZgrqYqZ8KhRWoLmi9dXgxi14b3wuD9afKWgf4t2dGSUaEWmNsZ9Xwa6MxtLA2WakTSVpNL4MGrHBFs9TRr99p9GLN5arF8PWnZNn7P2Gp/100/0)",
-        range: { 'non-ranged': 123123 }
+        range: { 'non-ranged': 123123n }
       },
       {
         descriptor:
           "pkh([a0809f04/44'/1'/10']tpubDDZgrqYqZ8Khmoc8cgxe51g1GchJ9F3MZHebGJEKkX5JtuRHUQysf4sSWiobEeEWNKjg7xVkZSZw549PU8LCwNRXRYhUZGfZ7xxNEE9uoPA/100/*)#52y3898q",
         range: {
-          1: 100000000,
-          4: 5000000,
-          14: 6000,
-          25: 1500000000
+          1: 100000000n,
+          4: 5000000n,
+          14: 6000n,
+          25: 1500000000n
         }
       },
       {
@@ -46,7 +46,7 @@ export const fixtures = {
       {
         descriptor:
           "pkh([a0809f04/44'/1'/12']tpubDDZgrqYqZ8KhsUuuUYn7Yu48sRy79zAZwps2Tv64RA3HJCmBkCUdeuj3UWz5vMEWBPUGMLF6jpkL9BWoWcbg2xJc5dcfpz8ooLFfboiZfa4/100/0)#4h3cswf0",
-        range: { 'non-ranged': 123123 }
+        range: { 'non-ranged': 123123n }
       },
       {
         descriptor:

--- a/test/integration/discovery.test.ts
+++ b/test/integration/discovery.test.ts
@@ -28,18 +28,21 @@ void EsploraExplorer;
 for (const network of [networks.bitcoin]) {
   //if (network.bech32 !== 'foo-bar') throw new Error('ENABLE THIS LATER');
   for (const explorerAndInfo of [
-    {
-      explorer: new EsploraExplorer({
-        url: 'https://blockstream.info/api/',
-        requestQueueParams: {
-          maxConcurrentTasks: 10
-          //maxConcurrentTasks: 30
-          //maxConcurrentTasks: 5 //default is 10
-          //maxAttemptsForHardErrors: 10 //default is 5
-        }
-      }),
-      info: 'EsploraExplorer'
-    },
+    // Public Esplora servers (blockstream.info or mempool.space are
+    // rate-limited; it's impossible to run this test below anymore:
+    //{
+    //  explorer: new EsploraExplorer({
+    //    //url: 'https://blockstream.info/api/',
+    //    url: 'https://mempool.space/api/',
+    //    requestQueueParams: {
+    //      maxConcurrentTasks: 10
+    //      //maxConcurrentTasks: 30
+    //      //maxConcurrentTasks: 5 //default is 10
+    //      //maxAttemptsForHardErrors: 10 //default is 5
+    //    }
+    //  }),
+    //  info: 'EsploraExplorer'
+    //},
     {
       explorer: new ElectrumExplorer({
         //host: 'btc.lastingcoin.net', //time out on bitcoind
@@ -73,7 +76,7 @@ for (const network of [networks.bitcoin]) {
     //Some servers: https://1209k.com/bitcoin-eye/ele.php
     //new EsploraExplorer({
     //  url:
-    //    network === networks.testnet
+    //    network.bech32 === networks.testnet.bech32
     //      ? 'https://blockstream.info/testnet/api'
     //      : 'https://blockstream.info/api', irrevConfThresh: 3, maxTxPerScriptPubKey: 1000
     //})
@@ -139,7 +142,7 @@ for (const network of [networks.bitcoin]) {
               descriptors,
               txStatus: TxStatus.ALL
             });
-            expect(balance).toEqual(0);
+            expect(balance).toEqual(0n);
             //console.log(`Balance for ${descriptors}: ${balance}`);
             const txHistory = discovery.getHistory({ descriptors });
             expect(txHistory.length).toBeGreaterThan(0);


### PR DESCRIPTION
This PR updates discovery to align with the same migration philosophy introduced in bitcoinerlab/descriptors#54 and bitcoinerlab/explorer#23. The codebase now targets bitcoinjs-lib v7 with descriptors v3 and explorer v1, replaces Buffer-specific byte handling with uint8array-tools and standardizes script/hash comparisons and hex conversions on Uint8Array semantics.

This release is intentionally breaking: monetary values exposed by the public API are now bigint. Any downstream code that assumed number types must be updated. Tests, fixtures, and README were adjusted accordingly to reflect the new baseline.